### PR TITLE
Stop relying on the pre_migrate signal to alter migration plan.

### DIFF
--- a/syzygy/management/commands/migrate.py
+++ b/syzygy/management/commands/migrate.py
@@ -1,14 +1,22 @@
-from django.apps import apps
 from django.core.management import CommandError
-from django.core.management.commands.migrate import (  # type: ignore
-    Command as MigrateCommand,
-)
-from django.db.models.signals import pre_migrate
+from django.core.management.commands import migrate  # type: ignore
+from django.db.migrations.executor import MigrationExecutor
 
 from syzygy.plan import get_pre_deploy_plan
 
 
-class Command(MigrateCommand):
+class PreDeployMigrationExecutor(MigrationExecutor):
+    def migration_plan(self, targets, clean_start=False):
+        plan = super().migration_plan(targets, clean_start=clean_start)
+        if not clean_start:
+            try:
+                plan = get_pre_deploy_plan(plan)
+            except ValueError as exc:
+                raise CommandError(str(exc)) from exc
+        return plan
+
+
+class Command(migrate.Command):
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
@@ -17,13 +25,12 @@ class Command(MigrateCommand):
             help="Only run migrations staged for pre-deployment.",
         )
 
-    def migrate_pre_deploy(self, plan, **kwargs):
-        try:
-            plan[:] = get_pre_deploy_plan(plan)
-        except ValueError as exc:
-            raise CommandError(str(exc)) from exc
-
     def handle(self, *args, pre_deploy, **options):
         if pre_deploy:
-            pre_migrate.connect(self.migrate_pre_deploy, sender=apps.get_app_config('syzygy'))
-        super().handle(*args, **options)
+            # Monkey-patch migrate.MigrationExecutor since the command doesn't
+            # allow it to be overridden in any other way.
+            migrate.MigrationExecutor = PreDeployMigrationExecutor
+        try:
+            super().handle(*args, **options)
+        finally:
+            migrate.MigrationExecutor = MigrationExecutor

--- a/syzygy/models.py
+++ b/syzygy/models.py
@@ -1,1 +1,0 @@
-# Empty models file in order to allow the pre_migrate signal to be sent.


### PR DESCRIPTION
Override the migrate command executor instead to allow support for the --plan
option.

Fixes #5.