### PR TITLE
Properly deconstruct custom operations.

### DIFF
--- a/syzygy/management/commands/migrate.py
+++ b/syzygy/management/commands/migrate.py
@@ -33,11 +33,11 @@ def _patch_executor(stage: Stage):
     doesn't allow it to be overridden in any other way.
     """
     if stage is Stage.PRE_DEPLOY:
-        migrate.MigrationExecutor = PreDeployMigrationExecutor
+        migrate.MigrationExecutor = PreDeployMigrationExecutor  # type: ignore
     try:
         yield
     finally:
-        migrate.MigrationExecutor = MigrationExecutor
+        migrate.MigrationExecutor = MigrationExecutor  # type: ignore
 
 
 class Command(migrate.Command):
@@ -206,7 +206,7 @@ class Command(migrate.Command):
             self.stdout.write("Migrations applied by remote party")
         return
 
-    def handle(
+    def handle(  # type: ignore
         self,
         *args,
         stage: Stage,

--- a/syzygy/operations.py
+++ b/syzygy/operations.py
@@ -121,10 +121,6 @@ class PreRemoveField(migrations.AlterField):
             )
         return "Set field %s of %s NULLable" % (self.name, self.model_name)
 
-    def deconstruct(self):
-        _, args, kwargs = super().deconstruct()
-        return f"{__name__}.{self.__class__.__name__}", args, kwargs
-
 
 class AddField(migrations.AddField):
     """
@@ -169,10 +165,6 @@ class AddField(migrations.AddField):
             return super().database_forwards(
                 app_label, schema_editor, from_state, to_state
             )
-
-    def deconstruct(self):
-        _, args, kwargs = super().deconstruct()
-        return f"{__name__}.{self.__class__.__name__}", args, kwargs
 
 
 class PostAddField(migrations.AlterField):
@@ -224,7 +216,3 @@ class PostAddField(migrations.AlterField):
             self.name,
             self.model_name,
         )
-
-    def deconstruct(self):
-        _, args, kwargs = super().deconstruct()
-        return f"{__name__}.{self.__class__.__name__}", args, kwargs

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple
 from django.db import connection, migrations, models
 from django.db.migrations.operations.base import Operation
 from django.db.migrations.optimizer import MigrationOptimizer
+from django.db.migrations.serializer import OperationSerializer
 from django.db.migrations.state import ProjectState
 from django.db.models.fields import NOT_PROVIDED
 from django.test import TestCase
@@ -85,11 +86,15 @@ class AddFieldTests(OperationTestCase):
         self.assertEqual(
             operation.deconstruct(),
             (
-                "syzygy.operations.AddField",
+                "AddField",
                 [],
                 {"model_name": model_name, "name": field_name, "field": field},
             ),
         )
+        serializer = OperationSerializer(operation)
+        serialized, imports = serializer.serialize()
+        self.assertTrue(serialized.startswith("syzygy.operations.AddField"))
+        self.assertIn("import syzygy.operations", imports)
 
 
 class PostAddFieldTests(OperationTestCase):
@@ -185,11 +190,15 @@ class PostAddFieldTests(OperationTestCase):
         self.assertEqual(
             operation.deconstruct(),
             (
-                "syzygy.operations.PostAddField",
+                "PostAddField",
                 [],
                 {"model_name": model_name, "name": field_name, "field": field},
             ),
         )
+        serializer = OperationSerializer(operation)
+        serialized, imports = serializer.serialize()
+        self.assertTrue(serialized.startswith("syzygy.operations.PostAddField"))
+        self.assertIn("import syzygy.operations", imports)
 
     def test_reduce(self):
         model_name = "TestModel"
@@ -276,19 +285,23 @@ class PreRemoveFieldTests(OperationTestCase):
         model_name = "TestModel"
         field_name = "foo"
         field = models.IntegerField(default=42)
-        operations = PreRemoveField(
+        operation = PreRemoveField(
             model_name,
             field_name,
             field,
         )
         self.assertEqual(
-            operations.deconstruct(),
+            operation.deconstruct(),
             (
-                "syzygy.operations.PreRemoveField",
+                "PreRemoveField",
                 [],
                 {"model_name": model_name, "name": field_name, "field": field},
             ),
         )
+        serializer = OperationSerializer(operation)
+        serialized, imports = serializer.serialize()
+        self.assertTrue(serialized.startswith("syzygy.operations.PreRemoveField"))
+        self.assertIn("import syzygy.operations", imports)
 
     def test_elidable(self):
         model_name = "TestModel"


### PR DESCRIPTION
Operation.deconstruct is actually expected to return only the operation name which contradicts the documented deconstruct behaviour.

Regression introduced by 5d29c7133cc2987a3f8e48a4d3d32feae207458e.