### PR TITLE
Fix #35 - Propagate migration crashes to quorum parties.

### DIFF
--- a/syzygy/quorum/__init__.py
+++ b/syzygy/quorum/__init__.py
@@ -5,14 +5,19 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
+from .backends.base import QuorumBase
+from .exceptions import QuorumDisolved
+
+__all__ = ("join_quorum", "sever_quorum", "poll_quorum", "QuorumDisolved")
+
 
 @lru_cache(maxsize=1)
-def _get_quorum(backend_path, **backend_options):
+def _get_quorum(backend_path, **backend_options) -> QuorumBase:
     backend_cls = import_string(backend_path)
     return backend_cls(**backend_options)
 
 
-def _get_configured_quorum():
+def _get_configured_quorum() -> QuorumBase:
     try:
         config: Union[dict, str] = settings.MIGRATION_QUORUM_BACKEND  # type: ignore
     except AttributeError:
@@ -48,6 +53,10 @@ def _get_configured_quorum():
 
 def join_quorum(namespace: str, quorum: int) -> bool:
     return _get_configured_quorum().join(namespace=namespace, quorum=quorum)
+
+
+def sever_quorum(namespace: str, quorum: int) -> bool:
+    return _get_configured_quorum().sever(namespace=namespace, quorum=quorum)
 
 
 def poll_quorum(namespace: str, quorum: int) -> bool:

--- a/syzygy/quorum/backends/base.py
+++ b/syzygy/quorum/backends/base.py
@@ -3,20 +3,34 @@ from abc import ABC, abstractmethod
 
 class QuorumBase(ABC):
     """
-    An abstraction to allow multiple clusters to obtain quorum before
-    proceeding with deployment stage.
+    An abstraction to allow multiple parties to obtain quorum before
+    proceeding with a coordinated action.
 
     For a particular `namespace` the `join` method must be called
     `quorum` times and `poll` must be called ``quorum - 1`` times or
-    for each member that got returned `False` when calling `join`.
+    for each party that got returned `False` when calling `join`.
+
+    The `sever` method must be called instead of `join` by parties
+    that do not intend to participate in attaining `namespace`'s quorum.
+    It must result in other parties raising `QuorumDisolved` on their next
+    `poll` for that `namespace`.
     """
 
     @abstractmethod
     def join(self, namespace: str, quorum: int) -> bool:
-        """Join the `namespace` and return whether or not `quorum` was reached."""
+        """Join the `namespace` and return whether or not `quorum` was attained."""
         ...
 
     @abstractmethod
+    def sever(self, namespace: str, quorum: int):
+        """Sever the `namespace`'s quorum attainment process."""
+
+    @abstractmethod
     def poll(self, namespace: str, quorum: int) -> bool:
-        """Return whether or not `namespace`'s `quorum` was reached."""
+        """
+        Return whether or not `namespace`'s `quorum` was reached.
+
+        Raise `QuorumDisolved` if the quorom attainment process was
+        severed.
+        """
         ...

--- a/syzygy/quorum/exceptions.py
+++ b/syzygy/quorum/exceptions.py
@@ -1,0 +1,2 @@
+class QuorumDisolved(Exception):
+    pass

--- a/tests/test_migrations/crash/0001_pre_deploy.py
+++ b/tests/test_migrations/crash/0001_pre_deploy.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+from syzygy import Stage
+
+
+def crash(*args, **kwargs):
+    raise Exception("Test crash")
+
+
+class Migration(migrations.Migration):
+    initial = True
+    stage = Stage.PRE_DEPLOY
+    atomic = False
+
+    operations = [migrations.RunPython(crash)]

--- a/tests/test_quorum.py
+++ b/tests/test_quorum.py
@@ -1,12 +1,18 @@
 import time
 import uuid
 from multiprocessing.pool import ThreadPool
+from random import shuffle
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test.testcases import SimpleTestCase
 from django.test.utils import override_settings
 
-from syzygy.quorum import join_quorum, poll_quorum
+from syzygy.quorum import (
+    QuorumDisolved,
+    join_quorum,
+    poll_quorum,
+    sever_quorum,
+)
 
 
 class QuorumConfigurationTests(SimpleTestCase):
@@ -49,6 +55,8 @@ class QuorumConfigurationTests(SimpleTestCase):
 
 
 class BaseQuorumTestMixin:
+    quorum = 5
+
     def test_multiple(self):
         namespace = str(uuid.uuid4())
         self.assertFalse(join_quorum(namespace, 2))
@@ -56,28 +64,67 @@ class BaseQuorumTestMixin:
         self.assertTrue(join_quorum(namespace, 2))
         self.assertTrue(poll_quorum(namespace, 2))
 
-    def test_thread_safety(self):
-        quorum = 5
+    @classmethod
+    def attain_quorum(cls, namespace):
+        if join_quorum(namespace, cls.quorum):
+            return True
+        while not poll_quorum(namespace, cls.quorum):
+            time.sleep(0.01)
+        return False
 
-        def achieve_quorum(namespace):
-            if join_quorum(namespace, quorum):
-                return True
-            while not poll_quorum(namespace, quorum):
-                time.sleep(0.01)
-            return False
+    def test_attainment(self):
+        namespace = str(uuid.uuid4())
 
-        with ThreadPool(processes=quorum) as pool:
-            results = pool.map_async(achieve_quorum, [str(uuid.uuid4())] * quorum).get()
+        with ThreadPool(processes=self.quorum) as pool:
+            results = pool.map_async(
+                self.attain_quorum, [namespace] * self.quorum
+            ).get()
 
         self.assertEqual(sum(1 for result in results if result is True), 1)
         self.assertEqual(sum(1 for result in results if result is False), 4)
 
-    def test_namespace_reuse(self):
+    def test_attainment_namespace_reuse(self):
         namespace = str(uuid.uuid4())
         self.assertFalse(join_quorum(namespace, 2))
         self.assertTrue(join_quorum(namespace, 2))
         self.assertTrue(poll_quorum(namespace, 2))
-        # Once quorum is reached its associated is immediately cleared and reusable.
+        # Once quorum is reached its associated namespace is immediately
+        # cleared to make it reusable.
+        self.assertFalse(join_quorum(namespace, 2))
+        self.assertTrue(join_quorum(namespace, 2))
+        self.assertTrue(poll_quorum(namespace, 2))
+
+    def test_disolution(self):
+        namespace = str(uuid.uuid4())
+
+        calls = [(self.attain_quorum, (namespace,))] * (self.quorum - 1)
+        calls.append((sever_quorum, (namespace, self.quorum)))
+        shuffle(calls)
+
+        with ThreadPool(processes=self.quorum) as pool:
+            results = [pool.apply_async(func, args) for func, args in calls]
+            pool.close()
+            pool.join()
+
+        disolved = 0
+        for result in results:
+            try:
+                attained = result.get()
+            except QuorumDisolved:
+                disolved += 1
+            else:
+                if attained is not None:
+                    self.fail(f"Unexpected quorum attainment: {attained}")
+        self.assertEqual(disolved, self.quorum - 1)
+
+    def test_disolution_namespace_reuse(self):
+        namespace = str(uuid.uuid4())
+        self.assertFalse(join_quorum(namespace, 2))
+        sever_quorum(namespace, 2)
+        with self.assertRaises(QuorumDisolved):
+            poll_quorum(namespace, 2)
+        # Once quorum is disolved its associated namespace is immediately
+        # cleared to make it reusable.
         self.assertFalse(join_quorum(namespace, 2))
         self.assertTrue(join_quorum(namespace, 2))
         self.assertTrue(poll_quorum(namespace, 2))


### PR DESCRIPTION
This ensures remote parties terminate immediately when the party that attained pre-migration quorum crashes when applying migrations.

This is achieved by introducing a concept of quorum severance and implemented in the cache backend by assigning a negative quorum value to the namespace which can be detected by other parties.