### PR TITLE
Fix #56 -- Address improper monkey-patching of migration_name_fragment.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@
 - Drop support for Python 3.8.
 - Ensure staged renames and alters are properly serialized. (#52)
 - Address improper handling of rename operation questioning. (#53)
+- Address improper monkey-patching of `AlterField.migration_name_fragment`. (#56)
 
 1.1.0
 =====

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -409,7 +409,12 @@ class PreRemoveFieldTests(OperationTestCase):
                 (
                     "AlterField",
                     [],
-                    {"model_name": model_name, "name": field_name, "field": mock.ANY},
+                    {
+                        "model_name": model_name,
+                        "name": field_name,
+                        "field": mock.ANY,
+                        "stage": Stage.PRE_DEPLOY,
+                    },
                 ),
             )
             self.assertEqual(
@@ -490,3 +495,14 @@ class AlterFieldTests(OperationTestCase):
             operation.field.deconstruct(), models.IntegerField().deconstruct()
         )
         self.assertEqual(operation.stage, Stage.PRE_DEPLOY)
+
+    def test_migration_name_fragment(self):
+        operation = AlterField(
+            "model",
+            "field",
+            models.IntegerField(),
+            Stage.PRE_DEPLOY,
+        )
+        self.assertEqual(operation.migration_name_fragment, "alter_model_field")
+        operation.migration_name_fragment = "alter_what_ever"
+        self.assertEqual(operation.migration_name_fragment, "alter_what_ever")


### PR DESCRIPTION
Instead of attempting to monkey-patch AlterField.migration_name_fragment use syzygy's subclass to define the attribute in an overridable way for the get_pre_remove_field_operation method.