### PR TITLE
Fix #60 -- Adjust pre-AddField(db_default) for ForeignKey with callable defaults.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@
 
 - Avoid unnecessary prompting for a default value on `ManyToManyField`
   removals. (#59)
+- Address a ``makemigration`` crash when adding a ``ForeignKey`` with a
+  callable ``default``. (#60)
 
 1.2.0
 =====

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,3 +3,10 @@ from django.db import models
 
 class Foo(models.Model):
     pass
+
+
+class Bar(models.Model):
+    name = models.CharField(max_length=100, unique=True)
+
+    class Meta:
+        managed = False

--- a/tests/test_migrations/null_field_removal/0001_initial.py
+++ b/tests/test_migrations/null_field_removal/0001_initial.py
@@ -19,4 +19,20 @@ class Migration(migrations.Migration):
                 ("bar", models.IntegerField()),
             ],
         ),
+        migrations.CreateModel(
+            "Bar",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(unique=True)),
+            ],
+            options={"managed": False},
+        ),
     ]


### PR DESCRIPTION
`ForeignKey.get_default()` cannot be safely called on instances that are not bound to a model yet; this will have to be adjusted if Django's schema editor is ever adjusted to operate from model states.

Thanks @jzmiller1 for the report.