### PR TITLE
Fix #69 -- Ensure effective default for pre-deploy add field db_default.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+1.2.3
+=====
+
+:release-date: not-released
+
+- Address an improper pre-deploy migration generation issue on Django 5.2+
+  when adding a field with an implicit default (e.g. ``Field.auto_now``). (#69)
+
 1.2.2
 =====
 

--- a/syzygy/operations.py
+++ b/syzygy/operations.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 from django.db import models
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations import operations
 from django.db.models.fields import NOT_PROVIDED
 from django.utils.functional import cached_property
@@ -137,7 +138,7 @@ def _get_field_default(field):
             target_field = field.to_fields[0] or "pk"
             field_default = getattr(field_default, target_field)
     else:
-        field_default = field.get_default()
+        field_default = BaseDatabaseSchemaEditor._effective_default(field)
     return field_default
 
 

--- a/syzygy/operations.py
+++ b/syzygy/operations.py
@@ -207,7 +207,7 @@ class AddField(operations.AddField):
         model = to_state.apps.get_model(app_label, self.model_name)
         if not self.allow_migrate_model(schema_editor.connection.alias, model):
             return
-        # Defer the removal of DEFAUT to `PostAddField`
+        # Defer the removal of DEFAULT to `PostAddField`
         with self._preserve_column_default(schema_editor, model):
             return super().database_forwards(
                 app_label, schema_editor, from_state, to_state

--- a/tests/test_autodetector.py
+++ b/tests/test_autodetector.py
@@ -10,6 +10,7 @@ from django.db.migrations.questioner import (
 from django.db.migrations.state import ModelState, ProjectState
 from django.test import TestCase
 from django.test.utils import captured_stderr, captured_stdin, captured_stdout
+from django.utils import timezone
 
 from syzygy.autodetector import STAGE_SPLIT, MigrationAutodetector
 from syzygy.compat import field_db_default_supported
@@ -113,6 +114,24 @@ class AutodetectorTests(AutodetectorTestCase):
                 expected_db_default = None
             with self.subTest(field=field):
                 self._test_field_addition(field, expected_db_default)
+
+    def test_auto_now_field_addition(self):
+        from_model = ModelState("tests", "Model", [])
+        to_model = ModelState(
+            "tests", "Model", [("updated", models.DateTimeField(auto_now=True))]
+        )
+        now = timezone.now()
+        with mock.patch("django.utils.timezone.now", return_value=now):
+            changes = self.get_changes([from_model], [to_model])["tests"]
+        self.assertEqual(len(changes), 2)
+        self.assertEqual(get_migration_stage(changes[0]), Stage.PRE_DEPLOY)
+        pre_operation = changes[0].operations[0]
+        if field_db_default_supported:
+            self.assertIsInstance(pre_operation, migrations.AddField)
+            self.assertEqual(pre_operation.field.db_default, now)
+        else:
+            self.assertIsInstance(pre_operation, AddField)
+        self.assertEqual(get_migration_stage(changes[1]), Stage.POST_DEPLOY)
 
     def test_many_to_many_addition(self):
         from_model = ModelState("tests", "Model", [])


### PR DESCRIPTION
The schema editor specialize certain field additions that don't define an explicit `Field.default` such as:

- `(Date|Time|DateTime)Field.auto_now(_add)?`
- `(Text|Char|BinaryField)(blank=True)`
- `GeneratedField`

so it's important that the pre-deploy operation captures this nuance as well.

Thanks @oliverhaas for the report and test.